### PR TITLE
Fix inconsistent error messages between get_profile and delete_profile (#16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 venv/
 .vscode/
 .idea/
+__pycache__/
+*.pyc
+

--- a/app/main.py
+++ b/app/main.py
@@ -60,7 +60,7 @@ def get_profile(username: str):
 def delete_profile(username: str):
     """Delete a user profile by username."""
     if username not in profile_store:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=404, detail="Profile not found")
     del profile_store[username]
     return {"deleted": True}
 


### PR DESCRIPTION
This PR resolves Issue #16 by making error messages consistent
between get_profile and delete_profile endpoints.

Both now return:
"Profile not found"
