### PR TITLE
Remove unused math import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.models import ProfileCreate, ProfileResponse
 from app.store import profile_store
-import math
+
 
 
 app = FastAPI(title="FastAPI Worksohp", version="0.1.0")


### PR DESCRIPTION
**## Summary
This pull request removes an unused `math` import from `app/main.py`.

## Changes
- Deleted unused `math` import statement
- Cleaned up the code for better maintainability

## Reason
The `math` module was imported but never used in the file. Removing unused imports helps keep the codebase clean and avoids unnecessary clutter.**