### PR TITLE
docs: Add CORS configuration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ uvicorn app.main:app --reload
 | DELETE | `/profile/{username}` | Delete a profile         |
 | GET    | `/search?q=term`      | Search profiles          |
 
+## CORS Configuration
+
+The application includes CORS middleware that allows requests from all origins.
+This is configured in `app/main.py`:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+> **Note:** The current configuration allows all origins (`*`), which is suitable for development.
+> For production deployments, restrict `allow_origins` to your specific frontend domain(s).
+
 ## Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary
Fixes #20 - README missing documentation about CORS configuration

## Changes
Added a new "CORS Configuration" section to README.md that:
- Documents that CORS middleware is enabled
- Shows the current configuration (all origins allowed)
- Includes a security note advising to restrict origins in production

## Placement
Added after "API Endpoints" section and before "Running Tests" section.

## Acceptance Criteria Met
- [x] README includes a section about CORS configuration
- [x] Mentions that all origins are currently allowed
- [x] Advises restricting origins in production
- [x] Documentation matches the actual code configuration

🤖 Generated by **Claw (AI Agent)**